### PR TITLE
Native demo for bloom effect

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -3,7 +3,6 @@ name: Upload
 on:
   push:
     branches:
-      - master
       - main
   pull_request: {}
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -873,7 +873,7 @@
                   |h $ {} (:at 1656162533183) (:by |u0) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1656162535605) (:by |u0) (:text |:tab) (:type :leaf)
-                      |b $ {} (:at 1656225950340) (:by |u0) (:text |:branches) (:type :leaf)
+                      |b $ {} (:at 1656416678440) (:by |u0) (:text |:spin-city) (:type :leaf)
           |canvas $ {} (:at 1651655933539) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1651655933539) (:by |u0) (:text |def) (:type :leaf)
@@ -4868,6 +4868,11 @@
               |e $ {} (:at 1654955101703) (:by |u0) (:text |:augment) (:type :leaf)
               |f $ {} (:at 1654955105794) (:by |u0) (:text |:length) (:type :leaf)
               |h $ {} (:at 1654955071273) (:by |u0) (:text |:data) (:type :leaf)
+          |*fb-pair $ {} (:at 1656419303027) (:by |u0) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1656419328898) (:by |u0) (:text |defatom) (:type :leaf)
+              |b $ {} (:at 1656419325382) (:by |u0) (:text |*fb-pair) (:type :leaf)
+              |h $ {} (:at 1656419331344) (:by |u0) (:text |nil) (:type :leaf)
           |*local-array-counter $ {} (:at 1654955292292) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1654955293519) (:by |u0) (:text |defatom) (:type :leaf)
@@ -6498,6 +6503,22 @@
                         :data $ {}
                           |T $ {} (:at 1651662869380) (:by |u0) (:text |gl) (:type :leaf)
                           |b $ {} (:at 1651662871955) (:by |u0) (:text |@*gl-context) (:type :leaf)
+                      |C $ {} (:at 1656412782384) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1656412782384) (:by |u0) (:text |scaled-width) (:type :leaf)
+                          |b $ {} (:at 1656412782384) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656412782384) (:by |u0) (:text |*) (:type :leaf)
+                              |b $ {} (:at 1656412782384) (:by |u0) (:text |dpr) (:type :leaf)
+                              |h $ {} (:at 1656412782384) (:by |u0) (:text |js/window.innerWidth) (:type :leaf)
+                      |J $ {} (:at 1656412778924) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1656412778924) (:by |u0) (:text |scaled-height) (:type :leaf)
+                          |b $ {} (:at 1656412778924) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656412778924) (:by |u0) (:text |*) (:type :leaf)
+                              |b $ {} (:at 1656412778924) (:by |u0) (:text |dpr) (:type :leaf)
+                              |h $ {} (:at 1656412778924) (:by |u0) (:text |js/window.innerHeight) (:type :leaf)
                   |o $ {} (:at 1651661933692) (:by |u0) (:type :expr)
                     :data $ {}
                       |5 $ {} (:at 1655969136821) (:by |u0) (:text |;) (:type :leaf)
@@ -6597,6 +6618,80 @@
                                             :data $ {}
                                               |D $ {} (:at 1654265368123) (:by |u0) (:text |:spin-city) (:type :leaf)
                                               |T $ {} (:at 1654265358329) (:by |u0) (:text |@*uniform-data) (:type :leaf)
+                          |s $ {} (:at 1656419343693) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656419345373) (:by |u0) (:text |fb-pair) (:type :leaf)
+                              |b $ {} (:at 1656419346887) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656419347323) (:by |u0) (:text |let) (:type :leaf)
+                                  |b $ {} (:at 1656419347708) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656419347881) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1656419348227) (:by |u0) (:text |b) (:type :leaf)
+                                          |b $ {} (:at 1656419354322) (:by |u0) (:text |@*fb-pair) (:type :leaf)
+                                  |h $ {} (:at 1656419357134) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656419357563) (:by |u0) (:text |if) (:type :leaf)
+                                      |b $ {} (:at 1656419614156) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1656419614976) (:by |u0) (:text |and) (:type :leaf)
+                                          |T $ {} (:at 1656419358183) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1656419359052) (:by |u0) (:text |some?) (:type :leaf)
+                                              |b $ {} (:at 1656419359465) (:by |u0) (:text |b) (:type :leaf)
+                                          |b $ {} (:at 1656419624960) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |5 $ {} (:at 1656420649338) (:by |u0) (:text |&=) (:type :leaf)
+                                              |D $ {} (:at 1656420643553) (:by |u0) (:type :expr)
+                                                :data $ {}
+                                                  |D $ {} (:at 1656420644221) (:by |u0) (:text |[]) (:type :leaf)
+                                                  |T $ {} (:at 1656419633005) (:by |u0) (:text |scaled-width) (:type :leaf)
+                                                  |b $ {} (:at 1656420646282) (:by |u0) (:text |scaled-height) (:type :leaf)
+                                              |T $ {} (:at 1656419618701) (:by |u0) (:type :expr)
+                                                :data $ {}
+                                                  |D $ {} (:at 1656419661499) (:by |u0) (:text |&map:get) (:type :leaf)
+                                                  |L $ {} (:at 1656419662007) (:by |u0) (:text |b) (:type :leaf)
+                                                  |T $ {} (:at 1656420653214) (:by |u0) (:text |:size) (:type :leaf)
+                                      |h $ {} (:at 1656419644736) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |D $ {} (:at 1656419649566) (:by |u0) (:text |&map:get) (:type :leaf)
+                                          |T $ {} (:at 1656419360366) (:by |u0) (:text |b) (:type :leaf)
+                                          |b $ {} (:at 1656419659267) (:by |u0) (:text |:buffer) (:type :leaf)
+                                      |l $ {} (:at 1656419361028) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1656419369947) (:by |u0) (:text |let) (:type :leaf)
+                                          |b $ {} (:at 1656419371299) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1656419371483) (:by |u0) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1656419373363) (:by |u0) (:text |f) (:type :leaf)
+                                                  |b $ {} (:at 1656419373844) (:by |u0) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1656419373844) (:by |u0) (:text |createTextureAndFramebuffer) (:type :leaf)
+                                                      |b $ {} (:at 1656419373844) (:by |u0) (:text |gl) (:type :leaf)
+                                                      |h $ {} (:at 1656419373844) (:by |u0) (:text |scaled-width) (:type :leaf)
+                                                      |l $ {} (:at 1656419373844) (:by |u0) (:text |scaled-height) (:type :leaf)
+                                          |h $ {} (:at 1656419377420) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1656419380453) (:by |u0) (:text |reset!) (:type :leaf)
+                                              |X $ {} (:at 1656419385104) (:by |u0) (:text |*fb-pair) (:type :leaf)
+                                              |b $ {} (:at 1656419573541) (:by |u0) (:type :expr)
+                                                :data $ {}
+                                                  |D $ {} (:at 1656419574982) (:by |u0) (:text |{}) (:type :leaf)
+                                                  |T $ {} (:at 1656419576327) (:by |u0) (:type :expr)
+                                                    :data $ {}
+                                                      |D $ {} (:at 1656419577872) (:by |u0) (:text |:buffer) (:type :leaf)
+                                                      |T $ {} (:at 1656419382411) (:by |u0) (:text |f) (:type :leaf)
+                                                  |b $ {} (:at 1656419578782) (:by |u0) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1656419584983) (:by |u0) (:text |:size) (:type :leaf)
+                                                      |b $ {} (:at 1656419585376) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656419586953) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656419597958) (:by |u0) (:text |scaled-width) (:type :leaf)
+                                                          |h $ {} (:at 1656419602606) (:by |u0) (:text |scaled-height) (:type :leaf)
+                                          |l $ {} (:at 1656419385953) (:by |u0) (:text |f) (:type :leaf)
                       |h $ {} (:at 1651661950631) (:by |u0) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1651661950631) (:by |u0) (:text |twgl/resizeCanvasToDisplaySize) (:type :leaf)
@@ -6605,36 +6700,40 @@
                               |T $ {} (:at 1651661950631) (:by |u0) (:text |.-canvas) (:type :leaf)
                               |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
                           |h $ {} (:at 1654918631813) (:by |u0) (:text |dpr) (:type :leaf)
-                      |l $ {} (:at 1651661950631) (:by |u0) (:type :expr)
+                      |hD $ {} (:at 1656416596631) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1651661950631) (:by |u0) (:text |.!viewport) (:type :leaf)
-                          |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
-                          |h $ {} (:at 1651661950631) (:by |u0) (:text |0) (:type :leaf)
-                          |l $ {} (:at 1651756673819) (:by |u0) (:text |0.0) (:type :leaf)
-                          |n $ {} (:at 1654918995920) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1656416596631) (:by |u0) (:text |.!bindFramebuffer) (:type :leaf)
+                          |b $ {} (:at 1656416596631) (:by |u0) (:text |gl) (:type :leaf)
+                          |h $ {} (:at 1656416596631) (:by |u0) (:type :expr)
                             :data $ {}
-                              |b $ {} (:at 1654918995920) (:by |u0) (:text |*) (:type :leaf)
-                              |e $ {} (:at 1654918999376) (:by |u0) (:text |dpr) (:type :leaf)
-                              |h $ {} (:at 1654918995920) (:by |u0) (:text |js/window.innerWidth) (:type :leaf)
-                          |nT $ {} (:at 1654919010472) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1656416596631) (:by |u0) (:text |.-FRAMEBUFFER) (:type :leaf)
+                              |b $ {} (:at 1656416596631) (:by |u0) (:text |gl) (:type :leaf)
+                          |l $ {} (:at 1656416596631) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1654919010472) (:by |u0) (:text |*) (:type :leaf)
-                              |b $ {} (:at 1654919010472) (:by |u0) (:text |dpr) (:type :leaf)
-                              |h $ {} (:at 1654919010472) (:by |u0) (:text |js/window.innerHeight) (:type :leaf)
-                          |o $ {} (:at 1651661950631) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1656416596631) (:by |u0) (:text |.-fb) (:type :leaf)
+                              |b $ {} (:at 1656416596631) (:by |u0) (:text |fb-pair) (:type :leaf)
+                      |hL $ {} (:at 1656417374313) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1656417374313) (:by |u0) (:text |.!viewport) (:type :leaf)
+                          |b $ {} (:at 1656417374313) (:by |u0) (:text |gl) (:type :leaf)
+                          |h $ {} (:at 1656417374313) (:by |u0) (:text |0) (:type :leaf)
+                          |l $ {} (:at 1656417374313) (:by |u0) (:text |0.0) (:type :leaf)
+                          |o $ {} (:at 1656417374313) (:by |u0) (:text |scaled-width) (:type :leaf)
+                          |q $ {} (:at 1656417374313) (:by |u0) (:text |scaled-height) (:type :leaf)
+                          |s $ {} (:at 1656417374313) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1654919001441) (:by |u0) (:text |;) (:type :leaf)
-                              |T $ {} (:at 1651661950631) (:by |u0) (:text |->) (:type :leaf)
-                              |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
-                              |h $ {} (:at 1651661950631) (:by |u0) (:text |.-canvas) (:type :leaf)
-                              |l $ {} (:at 1651661950631) (:by |u0) (:text |.-width) (:type :leaf)
-                          |q $ {} (:at 1651661950631) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1656417374313) (:by |u0) (:text |;) (:type :leaf)
+                              |b $ {} (:at 1656417374313) (:by |u0) (:text |->) (:type :leaf)
+                              |h $ {} (:at 1656417374313) (:by |u0) (:text |gl) (:type :leaf)
+                              |l $ {} (:at 1656417374313) (:by |u0) (:text |.-canvas) (:type :leaf)
+                              |o $ {} (:at 1656417374313) (:by |u0) (:text |.-width) (:type :leaf)
+                          |t $ {} (:at 1656417374313) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1654919000890) (:by |u0) (:text |;) (:type :leaf)
-                              |T $ {} (:at 1651661950631) (:by |u0) (:text |->) (:type :leaf)
-                              |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
-                              |h $ {} (:at 1651661950631) (:by |u0) (:text |.-canvas) (:type :leaf)
-                              |l $ {} (:at 1651661950631) (:by |u0) (:text |.-height) (:type :leaf)
+                              |T $ {} (:at 1656417374313) (:by |u0) (:text |;) (:type :leaf)
+                              |b $ {} (:at 1656417374313) (:by |u0) (:text |->) (:type :leaf)
+                              |h $ {} (:at 1656417374313) (:by |u0) (:text |gl) (:type :leaf)
+                              |l $ {} (:at 1656417374313) (:by |u0) (:text |.-canvas) (:type :leaf)
+                              |o $ {} (:at 1656417374313) (:by |u0) (:text |.-height) (:type :leaf)
                       |o $ {} (:at 1651661950631) (:by |u0) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1651661950631) (:by |u0) (:text |.!enable) (:type :leaf)
@@ -6653,7 +6752,7 @@
                               |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
                       |oX $ {} (:at 1651661950631) (:by |u0) (:type :expr)
                         :data $ {}
-                          |D $ {} (:at 1651840465292) (:by |u0) (:text |;) (:type :leaf)
+                          |D $ {} (:at 1656416445685) (:by |u0) (:text |;) (:type :leaf)
                           |T $ {} (:at 1651839345772) (:by |u0) (:text |.!depthFunc) (:type :leaf)
                           |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
                           |h $ {} (:at 1651661950631) (:by |u0) (:type :expr)
@@ -6665,15 +6764,6 @@
                           |T $ {} (:at 1651840184068) (:by |u0) (:text |.!depthMask) (:type :leaf)
                           |b $ {} (:at 1651840185523) (:by |u0) (:text |gl) (:type :leaf)
                           |h $ {} (:at 1651840186695) (:by |u0) (:text |true) (:type :leaf)
-                      |oj $ {} (:at 1651661950631) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |D $ {} (:at 1651840275813) (:by |u0) (:text |;) (:type :leaf)
-                          |T $ {} (:at 1651839348068) (:by |u0) (:text |.!depthFunc) (:type :leaf)
-                          |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
-                          |h $ {} (:at 1651661950631) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1651839311020) (:by |u0) (:text |.-GREATER) (:type :leaf)
-                              |b $ {} (:at 1651661950631) (:by |u0) (:text |gl) (:type :leaf)
                       |or $ {} (:at 1651661950631) (:by |u0) (:type :expr)
                         :data $ {}
                           |D $ {} (:at 1651840014180) (:by |u0) (:text |;) (:type :leaf)
@@ -6732,29 +6822,29 @@
                             :data $ {}
                               |T $ {} (:at 1651815822965) (:by |u0) (:text |.-FRONT_AND_BACK) (:type :leaf)
                               |b $ {} (:at 1651815810768) (:by |u0) (:text |gl) (:type :leaf)
-                      |rT $ {} (:at 1651840043044) (:by |u0) (:type :expr)
+                      |u $ {} (:at 1656417405561) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1651840043044) (:by |u0) (:text |.!clearColor) (:type :leaf)
-                          |b $ {} (:at 1651840043044) (:by |u0) (:text |gl) (:type :leaf)
-                          |h $ {} (:at 1651840043044) (:by |u0) (:text |0) (:type :leaf)
-                          |l $ {} (:at 1651840043044) (:by |u0) (:text |0) (:type :leaf)
-                          |o $ {} (:at 1651840043044) (:by |u0) (:text |0) (:type :leaf)
-                          |q $ {} (:at 1651840043044) (:by |u0) (:text |1) (:type :leaf)
-                      |s $ {} (:at 1651840039851) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1656417405561) (:by |u0) (:text |.!clearColor) (:type :leaf)
+                          |b $ {} (:at 1656417405561) (:by |u0) (:text |gl) (:type :leaf)
+                          |h $ {} (:at 1656417405561) (:by |u0) (:text |0) (:type :leaf)
+                          |l $ {} (:at 1656417405561) (:by |u0) (:text |0) (:type :leaf)
+                          |o $ {} (:at 1656417405561) (:by |u0) (:text |0) (:type :leaf)
+                          |q $ {} (:at 1656417405561) (:by |u0) (:text |1) (:type :leaf)
+                      |v $ {} (:at 1656417410809) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1651840039851) (:by |u0) (:text |.!clear) (:type :leaf)
-                          |b $ {} (:at 1651840039851) (:by |u0) (:text |gl) (:type :leaf)
-                          |h $ {} (:at 1651840039851) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1656417410809) (:by |u0) (:text |.!clear) (:type :leaf)
+                          |b $ {} (:at 1656417410809) (:by |u0) (:text |gl) (:type :leaf)
+                          |h $ {} (:at 1656417410809) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1651840039851) (:by |u0) (:text |or) (:type :leaf)
-                              |b $ {} (:at 1651840039851) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1656417410809) (:by |u0) (:text |or) (:type :leaf)
+                              |b $ {} (:at 1656417410809) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1651840039851) (:by |u0) (:text |.-COLOR_BUFFER_BIT) (:type :leaf)
-                                  |b $ {} (:at 1651840039851) (:by |u0) (:text |gl) (:type :leaf)
-                              |h $ {} (:at 1651840039851) (:by |u0) (:type :expr)
+                                  |T $ {} (:at 1656417410809) (:by |u0) (:text |.-COLOR_BUFFER_BIT) (:type :leaf)
+                                  |b $ {} (:at 1656417410809) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656417410809) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1651840039851) (:by |u0) (:text |.-DEPTH_BUFFER_BIT) (:type :leaf)
-                                  |b $ {} (:at 1651840039851) (:by |u0) (:text |gl) (:type :leaf)
+                                  |T $ {} (:at 1656417410809) (:by |u0) (:text |.-DEPTH_BUFFER_BIT) (:type :leaf)
+                                  |b $ {} (:at 1656417410809) (:by |u0) (:text |gl) (:type :leaf)
                       |x $ {} (:at 1653323208458) (:by |u0) (:type :expr)
                         :data $ {}
                           |D $ {} (:at 1653323212600) (:by |u0) (:text |&doseq) (:type :leaf)
@@ -6875,6 +6965,182 @@
                                             :data $ {}
                                               |T $ {} (:at 1654135057282) (:by |u0) (:text |.-LINE_LOOP) (:type :leaf)
                                               |b $ {} (:at 1653323283334) (:by |u0) (:text |gl) (:type :leaf)
+                      |y $ {} (:at 1656413081469) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |D $ {} (:at 1656413082227) (:by |u0) (:text |let) (:type :leaf)
+                          |L $ {} (:at 1656413082727) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656413087701) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656413092284) (:by |u0) (:text |mix-program) (:type :leaf)
+                                  |b $ {} (:at 1656413920525) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656413920525) (:by |u0) (:text |twgl/createProgramInfo) (:type :leaf)
+                                      |b $ {} (:at 1656413920525) (:by |u0) (:text |gl) (:type :leaf)
+                                      |h $ {} (:at 1656413920525) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1656413920525) (:by |u0) (:text |js-array) (:type :leaf)
+                                          |b $ {} (:at 1656413940817) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1656413940668) (:by |u0) (:text |inline-shader) (:type :leaf)
+                                              |b $ {} (:at 1656413954643) (:by |u0) (:text "|\"effect.vert") (:type :leaf)
+                                          |h $ {} (:at 1656413940817) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1656413940668) (:by |u0) (:text |inline-shader) (:type :leaf)
+                                              |b $ {} (:at 1656413959807) (:by |u0) (:text "|\"effect.frag") (:type :leaf)
+                              |b $ {} (:at 1656413142614) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656413148942) (:by |u0) (:text |mix-buffer-info) (:type :leaf)
+                                  |b $ {} (:at 1656414045499) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656414050640) (:by |u0) (:text |twgl/createBufferInfoFromArrays) (:type :leaf)
+                                      |b $ {} (:at 1656414052315) (:by |u0) (:text |gl) (:type :leaf)
+                                      |h $ {} (:at 1656414440694) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1656414444412) (:by |u0) (:text |js-object) (:type :leaf)
+                                          |b $ {} (:at 1656414624666) (:by |u0) (:type :expr)
+                                            :data $ {}
+                                              |T $ {} (:at 1656414638054) (:by |u0) (:text |:position) (:type :leaf)
+                                              |h $ {} (:at 1656415123309) (:by |u0) (:type :expr)
+                                                :data $ {}
+                                                  |T $ {} (:at 1656415124027) (:by |u0) (:text |create-attribute-array) (:type :leaf)
+                                                  |b $ {} (:at 1656415125587) (:by |u0) (:type :expr)
+                                                    :data $ {}
+                                                      |T $ {} (:at 1656415126199) (:by |u0) (:text |[]) (:type :leaf)
+                                                      |b $ {} (:at 1656415127877) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656415128009) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656415128678) (:by |u0) (:text |-1) (:type :leaf)
+                                                          |h $ {} (:at 1656415129210) (:by |u0) (:text |-1) (:type :leaf)
+                                                      |h $ {} (:at 1656415130218) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656415130629) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656415131493) (:by |u0) (:text |1) (:type :leaf)
+                                                          |h $ {} (:at 1656415926027) (:by |u0) (:text |-1) (:type :leaf)
+                                                      |l $ {} (:at 1656415132665) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656415133062) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656415905852) (:by |u0) (:text |1) (:type :leaf)
+                                                          |h $ {} (:at 1656415927960) (:by |u0) (:text |1) (:type :leaf)
+                                                      |o $ {} (:at 1656415137962) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656415138354) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656415139198) (:by |u0) (:text |-1) (:type :leaf)
+                                                          |h $ {} (:at 1656415139820) (:by |u0) (:text |-1) (:type :leaf)
+                                                      |q $ {} (:at 1656415141286) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656415141595) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656415931261) (:by |u0) (:text |-1) (:type :leaf)
+                                                          |h $ {} (:at 1656415142380) (:by |u0) (:text |1) (:type :leaf)
+                                                      |s $ {} (:at 1656415142920) (:by |u0) (:type :expr)
+                                                        :data $ {}
+                                                          |T $ {} (:at 1656415143489) (:by |u0) (:text |[]) (:type :leaf)
+                                                          |b $ {} (:at 1656415144625) (:by |u0) (:text |1) (:type :leaf)
+                                                          |h $ {} (:at 1656415965585) (:by |u0) (:text |1) (:type :leaf)
+                          |P $ {} (:at 1656413228206) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656413228206) (:by |u0) (:text |.!bindFramebuffer) (:type :leaf)
+                              |b $ {} (:at 1656413228206) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656413228206) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656413228206) (:by |u0) (:text |.-FRAMEBUFFER) (:type :leaf)
+                                  |b $ {} (:at 1656413228206) (:by |u0) (:text |gl) (:type :leaf)
+                              |l $ {} (:at 1656413602173) (:by |u0) (:text |nil) (:type :leaf)
+                          |R $ {} (:at 1656413258196) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1656416567405) (:by |u0) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1656413258196) (:by |u0) (:text |.!clearColor) (:type :leaf)
+                              |b $ {} (:at 1656413258196) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656413258196) (:by |u0) (:text |0) (:type :leaf)
+                              |l $ {} (:at 1656413258196) (:by |u0) (:text |0) (:type :leaf)
+                              |o $ {} (:at 1656413258196) (:by |u0) (:text |0) (:type :leaf)
+                              |q $ {} (:at 1656413258196) (:by |u0) (:text |1) (:type :leaf)
+                          |S $ {} (:at 1656413264666) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1656416566806) (:by |u0) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1656413264666) (:by |u0) (:text |.!clear) (:type :leaf)
+                              |b $ {} (:at 1656413264666) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656413264666) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656413264666) (:by |u0) (:text |or) (:type :leaf)
+                                  |b $ {} (:at 1656413264666) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656413264666) (:by |u0) (:text |.-COLOR_BUFFER_BIT) (:type :leaf)
+                                      |b $ {} (:at 1656413264666) (:by |u0) (:text |gl) (:type :leaf)
+                                  |h $ {} (:at 1656413264666) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656413264666) (:by |u0) (:text |.-DEPTH_BUFFER_BIT) (:type :leaf)
+                                      |b $ {} (:at 1656413264666) (:by |u0) (:text |gl) (:type :leaf)
+                          |ST $ {} (:at 1656416348185) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1656416565894) (:by |u0) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1656416348185) (:by |u0) (:text |.!enable) (:type :leaf)
+                              |b $ {} (:at 1656416348185) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656416348185) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656416348185) (:by |u0) (:text |.-DEPTH_TEST) (:type :leaf)
+                                  |b $ {} (:at 1656416348185) (:by |u0) (:text |gl) (:type :leaf)
+                          |Sj $ {} (:at 1656416358207) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1656416489419) (:by |u0) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1656416358207) (:by |u0) (:text |.!depthFunc) (:type :leaf)
+                              |b $ {} (:at 1656416358207) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656416358207) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656416358207) (:by |u0) (:text |.-LESS) (:type :leaf)
+                                  |b $ {} (:at 1656416358207) (:by |u0) (:text |gl) (:type :leaf)
+                          |Sn $ {} (:at 1656416358207) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1656416565185) (:by |u0) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1656416358207) (:by |u0) (:text |.!depthFunc) (:type :leaf)
+                              |b $ {} (:at 1656416358207) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656416358207) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656416455298) (:by |u0) (:text |.-GREATER) (:type :leaf)
+                                  |b $ {} (:at 1656416358207) (:by |u0) (:text |gl) (:type :leaf)
+                          |Sr $ {} (:at 1656416367457) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1656416564156) (:by |u0) (:text |;) (:type :leaf)
+                              |T $ {} (:at 1656416367457) (:by |u0) (:text |.!depthMask) (:type :leaf)
+                              |b $ {} (:at 1656416367457) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656416367457) (:by |u0) (:text |true) (:type :leaf)
+                          |T $ {} (:at 1656413074583) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656413074583) (:by |u0) (:text |.!useProgram) (:type :leaf)
+                              |b $ {} (:at 1656413074583) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656414745042) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |D $ {} (:at 1656415193922) (:by |u0) (:text |.-program) (:type :leaf)
+                                  |T $ {} (:at 1656413080103) (:by |u0) (:text |mix-program) (:type :leaf)
+                          |b $ {} (:at 1656413103899) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656413103899) (:by |u0) (:text |twgl/setBuffersAndAttributes) (:type :leaf)
+                              |b $ {} (:at 1656413103899) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656414272206) (:by |u0) (:text |mix-program) (:type :leaf)
+                              |l $ {} (:at 1656414283629) (:by |u0) (:text |mix-buffer-info) (:type :leaf)
+                          |h $ {} (:at 1656413105505) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656413106920) (:by |u0) (:text |twgl/setUniforms) (:type :leaf)
+                              |b $ {} (:at 1656414273512) (:by |u0) (:text |mix-program) (:type :leaf)
+                              |h $ {} (:at 1656413158343) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656414207753) (:by |u0) (:text |js-object) (:type :leaf)
+                                  |b $ {} (:at 1656414208380) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1656414214313) (:by |u0) (:text |:tex1) (:type :leaf)
+                                      |b $ {} (:at 1656414217909) (:by |u0) (:type :expr)
+                                        :data $ {}
+                                          |T $ {} (:at 1656414224984) (:by |u0) (:text |.-tex) (:type :leaf)
+                                          |b $ {} (:at 1656414231899) (:by |u0) (:text |fb-pair) (:type :leaf)
+                          |l $ {} (:at 1656413118899) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1656413118899) (:by |u0) (:text |twgl/drawBufferInfo) (:type :leaf)
+                              |b $ {} (:at 1656413118899) (:by |u0) (:text |gl) (:type :leaf)
+                              |h $ {} (:at 1656413154060) (:by |u0) (:text |mix-buffer-info) (:type :leaf)
+                              |l $ {} (:at 1656413118899) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1656413131232) (:by |u0) (:text |.-TRIANGLES) (:type :leaf)
+                                  |b $ {} (:at 1656413118899) (:by |u0) (:text |gl) (:type :leaf)
           |reset-canvas-size! $ {} (:at 1653326723833) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1653326723833) (:by |u0) (:text |defn) (:type :leaf)
@@ -7160,6 +7426,14 @@
                         |b $ {} (:at 1654078475506) (:by |u0) (:text |mobile?) (:type :leaf)
                         |h $ {} (:at 1654918636750) (:by |u0) (:text |dpr) (:type :leaf)
                         |l $ {} (:at 1654954318816) (:by |u0) (:text |back-cone-scale) (:type :leaf)
+                        |o $ {} (:at 1656413948897) (:by |u0) (:text |inline-shader) (:type :leaf)
+                |zq $ {} (:at 1656412469181) (:by |u0) (:type :expr)
+                  :data $ {}
+                    |T $ {} (:at 1656412472235) (:by |u0) (:text "|\"./fb.js") (:type :leaf)
+                    |b $ {} (:at 1656412473802) (:by |u0) (:text |:refer) (:type :leaf)
+                    |h $ {} (:at 1656412474090) (:by |u0) (:type :expr)
+                      :data $ {}
+                        |T $ {} (:at 1656412474359) (:by |u0) (:text |createTextureAndFramebuffer) (:type :leaf)
       |triadica.global $ {}
         :configs $ {}
         :defs $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -104,7 +104,7 @@
                       |k $ {} (:at 1656218137331) (:by |u0) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1656218909540) (:by |u0) (:text |branch-angle) (:type :leaf)
-                          |b $ {} (:at 1656228651099) (:by |u0) (:text |0.9) (:type :leaf)
+                          |b $ {} (:at 1656444408572) (:by |u0) (:text |0.7) (:type :leaf)
                       |l $ {} (:at 1656217837262) (:by |u0) (:type :expr)
                         :data $ {}
                           |T $ {} (:at 1656217843764) (:by |u0) (:text |main-branch) (:type :leaf)
@@ -873,7 +873,7 @@
                   |h $ {} (:at 1656162533183) (:by |u0) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1656162535605) (:by |u0) (:text |:tab) (:type :leaf)
-                      |b $ {} (:at 1656416678440) (:by |u0) (:text |:spin-city) (:type :leaf)
+                      |b $ {} (:at 1656444777953) (:by |u0) (:text |:cubes) (:type :leaf)
           |canvas $ {} (:at 1651655933539) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1651655933539) (:by |u0) (:text |def) (:type :leaf)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -6668,10 +6668,10 @@
                                                   |T $ {} (:at 1656419373363) (:by |u0) (:text |f) (:type :leaf)
                                                   |b $ {} (:at 1656419373844) (:by |u0) (:type :expr)
                                                     :data $ {}
-                                                      |T $ {} (:at 1656419373844) (:by |u0) (:text |createTextureAndFramebuffer) (:type :leaf)
+                                                      |T $ {} (:at 1656431920522) (:by |u0) (:text |createTextureAndFramebuffer) (:type :leaf)
                                                       |b $ {} (:at 1656419373844) (:by |u0) (:text |gl) (:type :leaf)
-                                                      |h $ {} (:at 1656419373844) (:by |u0) (:text |scaled-width) (:type :leaf)
-                                                      |l $ {} (:at 1656419373844) (:by |u0) (:text |scaled-height) (:type :leaf)
+                                                      |h $ {} (:at 1656431894839) (:by |u0) (:text |scaled-width) (:type :leaf)
+                                                      |l $ {} (:at 1656431896479) (:by |u0) (:text |scaled-height) (:type :leaf)
                                           |h $ {} (:at 1656419377420) (:by |u0) (:type :expr)
                                             :data $ {}
                                               |T $ {} (:at 1656419380453) (:by |u0) (:text |reset!) (:type :leaf)
@@ -6832,19 +6832,8 @@
                           |q $ {} (:at 1656417405561) (:by |u0) (:text |1) (:type :leaf)
                       |v $ {} (:at 1656417410809) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1656417410809) (:by |u0) (:text |.!clear) (:type :leaf)
+                          |T $ {} (:at 1656431979757) (:by |u0) (:text |clear_gl) (:type :leaf)
                           |b $ {} (:at 1656417410809) (:by |u0) (:text |gl) (:type :leaf)
-                          |h $ {} (:at 1656417410809) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1656417410809) (:by |u0) (:text |or) (:type :leaf)
-                              |b $ {} (:at 1656417410809) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1656417410809) (:by |u0) (:text |.-COLOR_BUFFER_BIT) (:type :leaf)
-                                  |b $ {} (:at 1656417410809) (:by |u0) (:text |gl) (:type :leaf)
-                              |h $ {} (:at 1656417410809) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1656417410809) (:by |u0) (:text |.-DEPTH_BUFFER_BIT) (:type :leaf)
-                                  |b $ {} (:at 1656417410809) (:by |u0) (:text |gl) (:type :leaf)
                       |x $ {} (:at 1653323208458) (:by |u0) (:type :expr)
                         :data $ {}
                           |D $ {} (:at 1653323212600) (:by |u0) (:text |&doseq) (:type :leaf)
@@ -7048,7 +7037,6 @@
                               |l $ {} (:at 1656413602173) (:by |u0) (:text |nil) (:type :leaf)
                           |R $ {} (:at 1656413258196) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1656416567405) (:by |u0) (:text |;) (:type :leaf)
                               |T $ {} (:at 1656413258196) (:by |u0) (:text |.!clearColor) (:type :leaf)
                               |b $ {} (:at 1656413258196) (:by |u0) (:text |gl) (:type :leaf)
                               |h $ {} (:at 1656413258196) (:by |u0) (:text |0) (:type :leaf)
@@ -7057,20 +7045,8 @@
                               |q $ {} (:at 1656413258196) (:by |u0) (:text |1) (:type :leaf)
                           |S $ {} (:at 1656413264666) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1656416566806) (:by |u0) (:text |;) (:type :leaf)
-                              |T $ {} (:at 1656413264666) (:by |u0) (:text |.!clear) (:type :leaf)
+                              |T $ {} (:at 1656431983731) (:by |u0) (:text |clear_gl) (:type :leaf)
                               |b $ {} (:at 1656413264666) (:by |u0) (:text |gl) (:type :leaf)
-                              |h $ {} (:at 1656413264666) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1656413264666) (:by |u0) (:text |or) (:type :leaf)
-                                  |b $ {} (:at 1656413264666) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1656413264666) (:by |u0) (:text |.-COLOR_BUFFER_BIT) (:type :leaf)
-                                      |b $ {} (:at 1656413264666) (:by |u0) (:text |gl) (:type :leaf)
-                                  |h $ {} (:at 1656413264666) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1656413264666) (:by |u0) (:text |.-DEPTH_BUFFER_BIT) (:type :leaf)
-                                      |b $ {} (:at 1656413264666) (:by |u0) (:text |gl) (:type :leaf)
                           |ST $ {} (:at 1656416348185) (:by |u0) (:type :expr)
                             :data $ {}
                               |D $ {} (:at 1656416565894) (:by |u0) (:text |;) (:type :leaf)
@@ -7429,11 +7405,12 @@
                         |o $ {} (:at 1656413948897) (:by |u0) (:text |inline-shader) (:type :leaf)
                 |zq $ {} (:at 1656412469181) (:by |u0) (:type :expr)
                   :data $ {}
-                    |T $ {} (:at 1656412472235) (:by |u0) (:text "|\"./fb.js") (:type :leaf)
+                    |T $ {} (:at 1656432508869) (:by |u0) (:text "|\"@quatrefoil/triadica-lib") (:type :leaf)
                     |b $ {} (:at 1656412473802) (:by |u0) (:text |:refer) (:type :leaf)
                     |h $ {} (:at 1656412474090) (:by |u0) (:type :expr)
                       :data $ {}
                         |T $ {} (:at 1656412474359) (:by |u0) (:text |createTextureAndFramebuffer) (:type :leaf)
+                        |b $ {} (:at 1656431986511) (:by |u0) (:text |clear_gl) (:type :leaf)
       |triadica.global $ {}
         :configs $ {}
         :defs $ {}

--- a/compact.cirru
+++ b/compact.cirru
@@ -908,7 +908,7 @@
               ; .!cullFace gl $ .-BACK gl
               ; .!cullFace gl $ .-FRONT_AND_BACK gl
               .!clearColor gl 0 0 0 1
-              .!clear gl $ or (.-COLOR_BUFFER_BIT gl) (.-DEPTH_BUFFER_BIT gl)
+              clear_gl gl
               &doseq (object @*objects-buffer)
                 let
                     program-info $ :program object
@@ -931,8 +931,8 @@
                     js-object $ :position
                       create-attribute-array $ [] ([] -1 -1) ([] 1 -1) ([] 1 1) ([] -1 -1) ([] -1 1) ([] 1 1)
                 .!bindFramebuffer gl (.-FRAMEBUFFER gl) nil
-                ; .!clearColor gl 0 0 0 1
-                ; .!clear gl $ or (.-COLOR_BUFFER_BIT gl) (.-DEPTH_BUFFER_BIT gl)
+                .!clearColor gl 0 0 0 1
+                clear_gl gl
                 ; .!enable gl $ .-DEPTH_TEST gl
                 ; .!depthFunc gl $ .-LESS gl
                 ; .!depthFunc gl $ .-GREATER gl
@@ -979,7 +979,7 @@
           "\"twgl.js" :as twgl
           triadica.math :refer $ &v+ &v- c-distance
           triadica.config :refer $ half-pi mobile? dpr back-cone-scale inline-shader
-          "\"./fb.js" :refer $ createTextureAndFramebuffer
+          "\"@quatrefoil/triadica-lib" :refer $ createTextureAndFramebuffer clear_gl
     |triadica.global $ {}
       :defs $ {}
         |*gl-context $ quote (defatom *gl-context nil)

--- a/compact.cirru
+++ b/compact.cirru
@@ -135,7 +135,7 @@
     |triadica.app.main $ {}
       :defs $ {}
         |*store $ quote
-          defatom *store $ {} (:v 0) (:tab :branches)
+          defatom *store $ {} (:v 0) (:tab :spin-city)
         |canvas $ quote
           def canvas $ js/document.querySelector "\"canvas"
         |dispatch! $ quote
@@ -630,6 +630,7 @@
     |triadica.core $ {}
       :defs $ {}
         |%nested-attribute $ quote (defrecord %nested-attribute :augment :length :data)
+        |*fb-pair $ quote (defatom *fb-pair nil)
         |*local-array-counter $ quote (defatom *local-array-counter 0)
         |*tmp-changes $ quote (defatom *tmp-changes nil)
         |create-attribute-array $ quote
@@ -869,6 +870,8 @@
         |render-canvas! $ quote
           defn render-canvas! () $ let
               gl @*gl-context
+              scaled-width $ * dpr js/window.innerWidth
+              scaled-height $ * dpr js/window.innerHeight
             ; js/console.log @*viewer-position @*viewer-forward @*viewer-upward
             ; do (hud-display "\"position" @*viewer-position) (hud-display "\"forward" @*viewer-forward) (hud-display "\"upward" @*viewer-upward)
             let
@@ -880,13 +883,24 @@
                   :coneBackScale back-cone-scale
                   :viewportRatio $ / js/window.innerHeight js/window.innerWidth
                   :citySpin $ wo-log (:spin-city @*uniform-data)
+                fb-pair $ let
+                    b @*fb-pair
+                  if
+                    and (some? b)
+                      &= ([] scaled-width scaled-height) (&map:get b :size)
+                    &map:get b :buffer
+                    let
+                        f $ createTextureAndFramebuffer gl scaled-width scaled-height
+                      reset! *fb-pair $ {} (:buffer f)
+                        :size $ [] scaled-width scaled-height
+                      , f
               twgl/resizeCanvasToDisplaySize (.-canvas gl) dpr
-              .!viewport gl 0 0.0 (* dpr js/window.innerWidth) (* dpr js/window.innerHeight) (; -> gl .-canvas .-width) (; -> gl .-canvas .-height)
+              .!bindFramebuffer gl (.-FRAMEBUFFER gl) (.-fb fb-pair)
+              .!viewport gl 0 0.0 scaled-width scaled-height (; -> gl .-canvas .-width) (; -> gl .-canvas .-height)
               .!enable gl $ .-DEPTH_TEST gl
               .!depthFunc gl $ .-LESS gl
               ; .!depthFunc gl $ .-GREATER gl
               .!depthMask gl true
-              ; .!depthFunc gl $ .-GREATER gl
               ; .!depthFunc gl $ .-ALWAYS gl
               ; .!blendFunc gl (.-SRC_ALPHA gl) (.-ONE gl)
               ; .!enable gl $ .-BLEND gl
@@ -910,6 +924,24 @@
                     :lines $ twgl/drawBufferInfo gl buffer-info (.-LINES gl)
                     :line-strip $ twgl/drawBufferInfo gl buffer-info (.-LINE_STRIP gl)
                     :line-loop $ twgl/drawBufferInfo gl buffer-info (.-LINE_LOOP gl)
+              let
+                  mix-program $ twgl/createProgramInfo gl
+                    js-array (inline-shader "\"effect.vert") (inline-shader "\"effect.frag")
+                  mix-buffer-info $ twgl/createBufferInfoFromArrays gl
+                    js-object $ :position
+                      create-attribute-array $ [] ([] -1 -1) ([] 1 -1) ([] 1 1) ([] -1 -1) ([] -1 1) ([] 1 1)
+                .!bindFramebuffer gl (.-FRAMEBUFFER gl) nil
+                ; .!clearColor gl 0 0 0 1
+                ; .!clear gl $ or (.-COLOR_BUFFER_BIT gl) (.-DEPTH_BUFFER_BIT gl)
+                ; .!enable gl $ .-DEPTH_TEST gl
+                ; .!depthFunc gl $ .-LESS gl
+                ; .!depthFunc gl $ .-GREATER gl
+                ; .!depthMask gl true
+                .!useProgram gl $ .-program mix-program
+                twgl/setBuffersAndAttributes gl mix-program mix-buffer-info
+                twgl/setUniforms mix-program $ js-object
+                  :tex1 $ .-tex fb-pair
+                twgl/drawBufferInfo gl mix-buffer-info $ .-TRIANGLES gl
         |reset-canvas-size! $ quote
           defn reset-canvas-size! (canvas)
             ; -> canvas .-width $ set! (&* dpr js/window.innerWidth)
@@ -946,7 +978,8 @@
           triadica.hud :refer $ hud-display
           "\"twgl.js" :as twgl
           triadica.math :refer $ &v+ &v- c-distance
-          triadica.config :refer $ half-pi mobile? dpr back-cone-scale
+          triadica.config :refer $ half-pi mobile? dpr back-cone-scale inline-shader
+          "\"./fb.js" :refer $ createTextureAndFramebuffer
     |triadica.global $ {}
       :defs $ {}
         |*gl-context $ quote (defatom *gl-context nil)

--- a/compact.cirru
+++ b/compact.cirru
@@ -26,7 +26,7 @@
                 delta-angle 2.09
                 regress 0.74
                 segments 4
-                branch-angle 0.9
+                branch-angle 0.7
                 main-branch $ wo-log
                   [] position $ &v+ position (v-scale forward length)
                 side-branches $ ->
@@ -135,7 +135,7 @@
     |triadica.app.main $ {}
       :defs $ {}
         |*store $ quote
-          defatom *store $ {} (:v 0) (:tab :spin-city)
+          defatom *store $ {} (:v 0) (:tab :cubes)
         |canvas $ quote
           def canvas $ js/document.querySelector "\"canvas"
         |dispatch! $ quote

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@calcit/procs": "^0.5.46",
     "@quamolit/touch-control": "^0.0.11",
+    "@quatrefoil/triadica-lib": "^0.0.2",
     "mobile-detect": "^1.4.5",
     "twgl.js": "^4.23.1"
   }

--- a/package/README.md
+++ b/package/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/package/fb.js
+++ b/package/fb.js
@@ -1,0 +1,34 @@
+
+export function clear_gl(gl) {
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+}
+
+// code from https://stackoverflow.com/a/8682663/883571
+// share the framebuffer and texture to render image first
+export function createTextureAndFramebuffer(gl, width, height) {
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  const fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+
+  // add extra depth buffer since Texture2D buffer does not track depth
+  // https://webglfundamentals.org/webgl/lessons/webgl-render-to-texture.html
+
+  // TODO https://www.cs.cornell.edu/courses/cs4620/2017sp/cs4621/lecture08/exhibit02.html
+  // might be a better solution
+
+  // create a depth renderbuffer
+  const depthBuffer = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, depthBuffer);
+
+  // make a depth buffer and the same size as the targetTexture
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, width, height);
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthBuffer);
+
+  return {tex: tex, fb: fb};
+}

--- a/package/package.json
+++ b/package/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@quatrefoil/triadica-lib",
+  "version": "0.0.2",
+  "description": "reusable JavaScript for Triadica",
+  "main": "./fb.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "webgl"
+  ],
+  "author": "tiye",
+  "license": "ISC"
+}

--- a/shaders/effect.frag
+++ b/shaders/effect.frag
@@ -6,7 +6,7 @@ varying vec2 v_texcoord;
 uniform sampler2D tex1;
 
 float color_strength(vec4 color) {
-  return color.r * color.r * 1.2 + color.g * color.g * 1.5 + color.b * color.b * 0.4;
+  return dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
 }
 
 const float PI = 3.14159265358979323846;
@@ -15,31 +15,44 @@ float square(float x) {
   return x * x;
 }
 
+const float SQRT_2PI = 2.5066282746310002;
+
 float normal_distribution(float d, float sigma) {
-  return exp(-0.5 * square(d) / square(sigma)) / sigma / sqrt(2.0 * PI);
+  return exp(-0.5 * square(d / sigma)) / (sigma * SQRT_2PI);
 }
+
+const int repeat = 3;
 
 void main() {
   // probably should use different texture coords for each
   // texture for more flexibility but I'm lazy
   vec4 color1 = texture2D(tex1, v_texcoord);
-  // if (rgb_brightness(color1) > 2.0) {
-  //   gl_FragColor = color1;
-  //   return;
-  // }
+  if (color_strength(color1) > 1.0) {
+    gl_FragColor = color1;
+    return;
+  }
 
+  // vec4 glow = vec4(0.0, 0.0, 0.0, 1.0);
+  // int count = 0;
+  vec4 max_glow = vec4(0.0, 0.0, 0.0, 1.0);
+  float max_glow_value = 0.0;
 
-  vec4 glow = vec4(0.0, 0.0, 0.0, 1.0);
-  int count = 0;
-  for (int i = -4; i <= 4; i++) {
-    for (int j = -4; j <= 4; j++) {
+  for (int i = -repeat; i <= repeat; i++) {
+    for (int j = -repeat; j <= repeat; j++) {
       if (1 != 0 || j != 0) {
         vec4 color2 = texture2D(tex1, v_texcoord + vec2(i, j) / 800.0);
-        // glow += color2 * normal_distribution(0.02*length(vec2(i, j)), 0.2);
+        if ((color2.r + color2.g + color2.g) < 0.3) {
+          continue;
+        }
+        vec4 glow = color2 * normal_distribution(0.3*length(vec2(i, j)), 0.6);
         // float l = length(vec2(i, j));
         // glow += color2 / l / l;
-        glow += color2;
-        count += 1;
+        // glow += color2;
+        float v = color_strength(glow);
+        if (v > 0.2 && v > max_glow_value) {
+          max_glow = glow;
+          max_glow_value = v;
+        }
       }
     }
   }
@@ -47,9 +60,13 @@ void main() {
   // shadow /= 5000.0;
   gl_FragColor = color1;
 
-  glow /= float(count);
-  // if (rgb_brightness(glow) > 2.0) {
-    gl_FragColor = max(color1, glow * 1.0);
+  if (max_glow_value > color_strength(color1)) {
+    gl_FragColor = max_glow;
+  }
+
+  // glow /= float(count);
+  // if (color_strength(glow) > 0.4) {
+  //   gl_FragColor = mix(color1, glow, 0.5);
   // }
   // gl_FragColor = glow;
   // gl_FragColor = color1;

--- a/shaders/effect.frag
+++ b/shaders/effect.frag
@@ -1,0 +1,58 @@
+
+precision mediump float;
+
+varying vec2 v_texcoord;
+
+uniform sampler2D tex1;
+
+float color_strength(vec4 color) {
+  return color.r * color.r * 1.2 + color.g * color.g * 1.5 + color.b * color.b * 0.4;
+}
+
+const float PI = 3.14159265358979323846;
+
+float square(float x) {
+  return x * x;
+}
+
+float normal_distribution(float d, float sigma) {
+  return exp(-0.5 * square(d) / square(sigma)) / sigma / sqrt(2.0 * PI);
+}
+
+void main() {
+  // probably should use different texture coords for each
+  // texture for more flexibility but I'm lazy
+  vec4 color1 = texture2D(tex1, v_texcoord);
+  // if (rgb_brightness(color1) > 2.0) {
+  //   gl_FragColor = color1;
+  //   return;
+  // }
+
+
+  vec4 glow = vec4(0.0, 0.0, 0.0, 1.0);
+  int count = 0;
+  for (int i = -4; i <= 4; i++) {
+    for (int j = -4; j <= 4; j++) {
+      if (1 != 0 || j != 0) {
+        vec4 color2 = texture2D(tex1, v_texcoord + vec2(i, j) / 800.0);
+        // glow += color2 * normal_distribution(0.02*length(vec2(i, j)), 0.2);
+        // float l = length(vec2(i, j));
+        // glow += color2 / l / l;
+        glow += color2;
+        count += 1;
+      }
+    }
+  }
+  // shadow /= float(size);
+  // shadow /= 5000.0;
+  gl_FragColor = color1;
+
+  glow /= float(count);
+  // if (rgb_brightness(glow) > 2.0) {
+    gl_FragColor = max(color1, glow * 1.0);
+  // }
+  // gl_FragColor = glow;
+  // gl_FragColor = color1;
+  // gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+  // gl_FragColor = shadow;
+}

--- a/shaders/effect.vert
+++ b/shaders/effect.vert
@@ -1,0 +1,9 @@
+
+attribute vec2 a_position;
+
+varying vec2 v_texcoord;
+
+void main() {
+  gl_Position = vec4(a_position, 0.0, 1.0);
+  v_texcoord = a_position.xy * .5 + .5;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,11 @@
   resolved "https://registry.yarnpkg.com/@quamolit/touch-control/-/touch-control-0.0.11.tgz#f6d01a7ecac385d5f4955118b6d630958d660070"
   integrity sha512-v1ygM4gLeRkidbSil99dpdUcOjOR9EaWH448HEaQIwIWYYB4a58hCT0hSlGknPJRQxp8ZbjDo8T+LpZhCf8vfQ==
 
+"@quatrefoil/triadica-lib@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@quatrefoil/triadica-lib/-/triadica-lib-0.0.2.tgz#15fe24d7e21ea1dcaaf8534994be58108f152dbc"
+  integrity sha512-tty7yK3NBbFEZaJjcucJZ+FDRx7Kges9ht2Kj5hJXKFWJiGRNlTayTpnUaHq44Mrc90+9Dei/jnX4sFqaLbjqQ==
+
 bottom-tip@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/bottom-tip/-/bottom-tip-0.1.3.tgz#ad3a4bcc8c3d5b5c6dac68fd3d140bf18efc50f8"


### PR DESCRIPTION
managed to finish a very early example with help from:

- https://stackoverflow.com/a/8682663/883571
- https://www.cs.cornell.edu/courses/cs4620/2017sp/cs4621/lecture08/exhibit02.html

![image](https://user-images.githubusercontent.com/449224/176230988-0ffdd6d8-b766-4f3f-b691-def22947dec6.png)

however this is not real bloom effect given that the colors being more like blurs.

still problems including:

- how to calculate brightness(yellow is brighter), and tell pixel that does not need bloom
- setting up more reasonable buffers, currently only 1 framebuffer added, I'm not even sure if I made it wrong given that it's still different from the original example which as 2 extra buffers.
- and how to bloom nicely...

guess I still need help from https://github.com/greggman/twgl.js/issues/197 .


